### PR TITLE
Changing demo email

### DIFF
--- a/addons/crm/data/crm_lead_demo.xml
+++ b/addons/crm/data/crm_lead_demo.xml
@@ -545,7 +545,7 @@ Andrew</p>]]></field>
             <field eval="35000" name="expected_revenue"/>
             <field eval="25.0" name="probability"/>
             <field name="contact_name">Leland Martinez</field>
-            <field name="email_from">info@deltapc.com</field>
+            <field name="email_from">info2@fakedeltapc.com</field>
             <field name="partner_name">Delta PC</field>
             <field name="city">London</field>
             <field name="street">3661 Station Street</field>


### PR DESCRIPTION
Fake demo email used in our crm_lead demo data is an actual customer's email. 

Updating to a more distinctive fake email. 

https://www.odoo.com/web#id=2746911&cids=3&menu_id=4720&action=333&active_id=49&model=project.task&view_type=form

Description of the issue/feature this PR addresses:  Email used in our demo data is an actual customer's email.

Current behavior before PR:  Hundreds of emails were being sent to the customer as this demo data is used in trial databases.

Desired behavior after PR is merged:  Changing to a different (fake) email so customer is not affected. 




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
